### PR TITLE
Add transcription of 68-PA-T-257A

### DIFF
--- a/68-PA-T-257A.md
+++ b/68-PA-T-257A.md
@@ -1,0 +1,43 @@
+---
+layout: tindallgram
+date: Nov 25 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 68-PA-T-257A
+subject: LM DPS low level light fixing
+tags:
+    - LM
+    - landing
+    - DPS
+    - master alarm
+---
+I think this will amuse you. It's something that came up the other
+day during a Descent Abort Mission Techniques meeting.
+
+As you know, there is a light on the LM dashboard that comes on when
+there is about two minutes worth of propellant remaining in the DPS
+tanks with the engine operating at quarter thrust.  This is to give
+the crew an indication of how much time they have left to perform the
+landing or to abort out of there.  It compliments the propellant gauges.
+The present LM weight and descent trajectory is such that this light
+will always come on prior to touch down.  This signal, it turns out,
+is connected to the master alarm - how about that!  In other words,
+just at the most critical time in the most critical operation of a
+perfectly nominal lunar landing mission, the master alarm with all
+its lights, bells, and whistles will go off.  This sounds right lousy
+to me.  In fact, Pete Conrad tells me he labeled it completely unacceptable
+four or five years ago, but he was probably just an Ensign at the time
+and apparently no one paid any attention.  If this is not fixed, I predict
+the first words uttered by the first astronaut to land on the moon will be
+"Gee whiz, that master alarm certainly startled me."
+
+As I understand it, cutting the wire to the master alarm eliminates the
+low level sensor light too.  If nothing else can be done, this should be
+and we'll get along just using the propellant gauges without the light.
+If possible, a better fix would be to cut the wire on both sides of
+the master alarm and jumper the signal to the light only.
+
+Incidentally, on the D mission the propellant  levels will be low enough
+when we get to the DPS rendezvous maneuvers - Phasing and Insertion - that
+if this system is acticated prior to ullage, the master alarm will likely
+go off.  I guess it will be standard procedure to punch it off if that
+happens.  But, where this is just an annoyance on D, it is dangerous on G.


### PR DESCRIPTION
Adds a transcription of 68-PA-T-257A, which details the master alarm condition that would be triggered by the propellant low-level light in the LM Descent Propulsion System (DPS).

I've tried to follow the instructions for contributors as closely as I can. Punctuation and line breaks are preserved from the original. Let me know if I've messed anything up and I'll do my best to fix it!