### PR TITLE
Add 68-PA-T-49A

### DIFF
--- a/68-PA-T-49A.md
+++ b/68-PA-T-49A.md
@@ -22,40 +22,38 @@ subject: "Fifth \"D\" Mission Rendezvous Mission Techniques meeting---don't miss
    AGS must be maintained in optimum state to take over in the event the 
    PNGSCS fails. This applies to all maneuvers---CSI, CDH, TPI.
 
-   a. Checking of the PNGCS will be by comparison with the ground 
-      computed solution *only*. That is comparisons of maneuver 
-      targeting from other sources, such as the AGS, backup charts or 
-      the CSM will not be made to commit to the PNGCS. The PNGCS 
-      solution will be used providing it is within acceptable limits of 
-      the MSFN solution. One possible exception here is that, since the 
-      CSM optics provide very strong solutions to the TPI delta V 
-      components perpendicular to the line of sight, comparison with 
-      them may be advantageous.
+   (a). Checking of the PNGCS will be by comparison with the ground 
+   computed solution *only*. That is comparisons of maneuver targeting 
+   from other sources, such as the AGS, backup charts or the CSM will 
+   not be made to commit to the PNGCS. The PNGCS solution will be used 
+   providing it is within acceptable limits of the MSFN solution. One 
+   possible exception here is that, since the CSM optics provide very 
+   strong solutions to the TPI delta V components perpendicular to the 
+   line of sight, comparison with them may be advantageous.
 
-   b. The state vectors in the AGS will be updated each time PNGCS is 
-      confirmed to be acceptable. This will likely be at each time it is 
-      committed to make the next maneuver using the PNGCS.
+   (b). The state vectors in the AGS will be updated each time PNGCS is 
+   confirmed to be acceptable. This will likely be at each time it is 
+   committed to make the next maneuver using the PNGCS.
 
-   c. AGS alignments will be made each time the PNGCS is realigned and 
-      each time the state vector in the AGS is updated from the PNGCS.
+   (c). AGS alignments will be made each time the PNGCS is realigned and 
+   each time the state vector in the AGS is updated from the PNGCS.
 
-   d. No radar data will be input into the AGS as long as the PNGCS is 
-      working. In effect it is obtaining benefit of the radar via the 
-      PNGCS state vector updates since the PNGCS is processing the radar 
-      data.
+   (d). No radar data will be input into the AGS as long as the PNGCS is 
+   working. In effect it is obtaining benefit of the radar via the PNGCS 
+   state vector updates since the PNGCS is processing the radar data.
 
-   e. There is no need to prepare or learn to use backup charts for CSI 
-      and/or CDH maneuvers for this mission. Terminal phase charts are 
-      essential in the LM.
+   (e). There is no need to prepare or learn to use backup charts for 
+   CSI and/or CDH maneuvers for this mission. Terminal phase charts are 
+   essential in the LM.
 
 3. In the event of a PNGCS failure: CSI and CDH only.
 
-   a. For the CSI and CDH, use the AGS in almost the identical manner in 
-      which the Gemini spacecraft was flown .That is, use ground 
-      targeted maneuvers executed with the AGS External delta V mode.
+   (a). For the CSI and CDH, use the AGS in almost the identical manner 
+   in which the Gemini spacecraft was flown .That is, use ground 
+   targeted maneuvers executed with the AGS External delta V mode.
 
-   b. No radar data would be input into the AGS prior to the CSI and 
-      CDH.
+   (b). No radar data would be input into the AGS prior to the CSI and 
+   CDH.
 
 4. By far the most extensive discussion dealt with the Terminal Phase 
    Initiation (TPI) maneuver and subsequent midcourse maneuvers in the 
@@ -67,34 +65,32 @@ subject: "Fifth \"D\" Mission Rendezvous Mission Techniques meeting---don't miss
    alternative plans for TPI---PNGCS out, radar working---are as 
    follows:
 
-   a. Compare the onboard chart solution for TPI with the MSFN. If the 
-      comparison is favourable, execute the chart solution and, if not, 
-      use the MSFN delta V's and the maneuver execution time based on 
-      the onboard solution. The maneuver would be made using the AGS 
-      external delta V mode---this procedure to be amplified later in 
-      this memo. *Do not input radar* data into the AGS. OR...
+   (a). Compare the onboard chart solution for TPI with the MSFN. If the 
+   comparison is favourable, execute the chart solution and, if not, use 
+   the MSFN delta V's and the maneuver execution time based on the 
+   onboard solution. The maneuver would be made using the AGS external 
+   delta V mode---this procedure to be amplified later in this memo. *Do 
+   not input radar* data into the AGS. OR...
 
-   b. As soon as PNGCS failure is apparent (but not sooner than CDH) 
-      start updating AGS state vectors *with rendezvous radar data 
-      inputs*. Proceed using GS in place of PNGCS. That is, compare TPI 
-      solution with MSFN (and maybe CSM for components perpendicular to 
-      the line of sight). Use AGS solution if acceptable. If not, 
-      execute MSFN delta V's using AGS External Delta V mode. The 
-      argument for inputting rendezvous radar in the AGS and using its 
-      solution is that it is a closed loop system which analysis shows 
-      should work well using rendezvous radar and more analysis is on 
-      the way to prove it further. In addition, Flight Crew is concerned 
-      that the arithmetic associated with the charts makes its solution 
-      more susceptible to crew error, whereas the AGS does the 
-      arithmetic for them. The arguments against use of radar in the AGS 
-      for TPI is that to attempt to maintain both the AGS and charts 
-      solutions is likely to create an excessive work load upon the 
-      crew, particularly when considering the henderences of the 
-      spacesuits and the zero g environment. Furthermore, we have 
-      considerable confidence in the charts and expect that if the 
-      charts and AGS (with radar) solutions differ we would be inclined 
-      to believe the charts and use that solution instead of the AGS 
-      anyway.
+   (b). As soon as PNGCS failure is apparent (but not sooner than CDH) 
+   start updating AGS state vectors *with rendezvous radar data inputs*. 
+   Proceed using GS in place of PNGCS. That is, compare TPI solution 
+   with MSFN (and maybe CSM for components perpendicular to the line of 
+   sight). Use AGS solution if acceptable. If not, execute MSFN delta 
+   V's using AGS External Delta V mode. The argument for inputting 
+   rendezvous radar in the AGS and using its solution is that it is a 
+   closed loop system which analysis shows should work well using 
+   rendezvous radar and more analysis is on the way to prove it further. 
+   In addition, Flight Crew is concerned that the arithmetic associated 
+   with the charts makes its solution more susceptible to crew error, 
+   whereas the AGS does the arithmetic for them. The arguments against 
+   use of radar in the AGS for TPI is that to attempt to maintain both 
+   the AGS and charts solutions is likely to create an excessive work 
+   load upon the crew, particularly when considering the henderences of 
+   the spacesuits and the zero g environment. Furthermore, we have 
+   considerable confidence in the charts and expect that if the charts 
+   and AGS (with radar) solutions differ we would be inclined to believe 
+   the charts and use that solution instead of the AGS anyway.
 
 5. The following is the most startling conclusion reached today: IF the 
    LM PNGCS is working but rendezvous radar has failed, we have a 
@@ -104,14 +100,14 @@ subject: "Fifth \"D\" Mission Rendezvous Mission Techniques meeting---don't miss
    subsequent midcourse correction maneuvers and the LM do the braking 
    maneuvers.
 
-   a. The command module would compare its TPI solution with the MSFN. 
-      If the comparison is favorable that maneuver would be executed; if 
-      not, the command module would execute the MSFN delta V's using its 
-      own time of ignition.
+   (a). The command module would compare its TPI solution with the MSFN. 
+   If the comparison is favorable that maneuver would be executed; if 
+   not, the command module would execute the MSFN delta V's using its 
+   own time of ignition.
 
-   b. The command module would voice relay to the LM the maneuvers it 
-      has executed in order that the LM crew could update the command 
-      module state vectors in the LGC using the Target Delta V program. 
+   (b). The command module would voice relay to the LM the maneuvers it 
+   has executed in order that the LM crew could update the command 
+   module state vectors in the LGC using the Target Delta V program. 
 
 6. I would like to present here the rationale for making the command 
    module active for TPI and midcourse when only the rendezvous radar 

--- a/68-PA-T-49A.md
+++ b/68-PA-T-49A.md
@@ -59,7 +59,7 @@ subject: "Fifth \"D\" Mission Rendezvous Mission Techniques meeting---don't miss
 
 4. By far the most extensive discussion dealt with the Terminal Phase 
    Initiation (TPI) maneuver and subsequent midcourse maneuvers in the 
-   event of a PNGCS failure, but wi the radar still working. This was 
+   event of a PNGCS failure, but with the radar still working. This was 
    the one area still lacking agreement. It is all based on the 
    assumption that a rendezvous radar failure is obvious as opposed to 
    insidious. Clarke Hackler (GCD) and Al Nathan (GAEC) where given the 

--- a/68-PA-T-49A.md
+++ b/68-PA-T-49A.md
@@ -1,0 +1,161 @@
+---
+layout: tindallgram
+date: Mar 01 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 68-PA-TR-49A
+subject: "Fifth \"D\" Mission Rendezvous Mission Techniques meeting---don't miss Paragraph 5: It's great"
+---
+
+1. We spent just about the entire February 26 meeting discussing the way 
+   the AGS and PNGCS should be used during the "D" mission rendezvous. I 
+   feel as though we have accomplished quite a lot in this area having 
+   reached agreement on how the AGS should be used throughout that 
+   mission phase, with one minor exception. It is all based on the 
+   ground rule that on this mssion the AGS should be maintained in that 
+   state which makes it most useful to perform the rendezvous in the 
+   event of PNGCS failure. It was noted that if after having established 
+   the preferred techniques in accordance with that ground rule it is 
+   possible to include some AGS systems tests without jeopardizing crew 
+   safety or other mission objects, they would be considered.
+
+2. Nominal situation: PNGCS seams to be working properly and is prime; 
+   AGS must be maintained in optimum state to take over in the event the 
+   PNGSCS fails. This applies to all maneuvers---CSI, CDH, TPI.
+
+   a. Checking of the PNGCS will be by comparison with the ground 
+      computed solution *only*. That is comparisons of maneuver 
+      targeting from other sources, such as the AGS, backup charts or 
+      the CSM will not be made to commit to the PNGCS. The PNGCS 
+      solution will be used providing it is within acceptable limits of 
+      the MSFN solution. One possible exception here is that, since the 
+      CSM optics provide very strong solutions to the TPI delta V 
+      components perpendicular to the line of sight, comparison with 
+      them may be advantageous.
+
+   b. The state vectors in the AGS will be updated each time PNGCS is 
+      confirmed to be acceptable. This will likely be at each time it is 
+      committed to make the next maneuver using the PNGCS.
+
+   c. AGS alignments will be made each time the PNGCS is realigned and 
+      each time the state vector in the AGS is updated from the PNGCS.
+
+   d. No radar data will be input into the AGS as long as the PNGCS is 
+      working. In effect it is obtaining benefit of the radar via the 
+      PNGCS state vector updates since the PNGCS is processing the radar 
+      data.
+
+   e. There is no need to prepare or learn to use backup charts for CSI 
+      and/or CDH maneuvers for this mission. Terminal phase charts are 
+      essential in the LM.
+
+3. In the event of a PNGCS failure: CSI and CDH only.
+
+   a. For the CSI and CDH, use the AGS in almost the identical manner in 
+      which the Gemini spacecraft was flown .That is, use ground 
+      targeted maneuvers executed with the AGS External delta V mode.
+
+   b. No radar data would be input into the AGS prior to the CSI and 
+      CDH.
+
+4. By far the most extensive discussion dealt with the Terminal Phase 
+   Initiation (TPI) maneuver and subsequent midcourse maneuvers in the 
+   event of a PNGCS failure, but wi the radar still working. This was 
+   the one area still lacking agreement. It is all based on the 
+   assumption that a rendezvous radar failure is obvious as opposed to 
+   insidious. Clarke Hackler (GCD) and Al Nathan (GAEC) where given the 
+   action item to determine if this assumption is reasonable. Our 
+   alternative plans for TPI---PNGCS out, radar working---are as 
+   follows:
+
+   a. Compare the onboard chart solution for TPI with the MSFN. If the 
+      comparison is favourable, execute the chart solution and, if not, 
+      use the MSFN delta V's and the maneuver execution time based on 
+      the onboard solution. The maneuver would be made using the AGS 
+      external delta V mode---this procedure to be amplified later in 
+      this memo. *Do not input radar* data into the AGS. OR...
+
+   b. As soon as PNGCS failure is apparent (but not sooner than CDH) 
+      start updating AGS state vectors *with rendezvous radar data 
+      inputs*. Proceed using GS in place of PNGCS. That is, compare TPI 
+      solution with MSFN (and maybe CSM for components perpendicular to 
+      the line of sight). Use AGS solution if acceptable. If not, 
+      execute MSFN delta V's using AGS External Delta V mode. The 
+      argument for inputting rendezvous radar in the AGS and using its 
+      solution is that it is a closed loop system which analysis shows 
+      should work well using rendezvous radar and more analysis is on 
+      the way to prove it further. In addition, Flight Crew is concerned 
+      that the arithmetic associated with the charts makes its solution 
+      more susceptible to crew error, whereas the AGS does the 
+      arithmetic for them. The arguments against use of radar in the AGS 
+      for TPI is that to attempt to maintain both the AGS and charts 
+      solutions is likely to create an excessive work load upon the 
+      crew, particularly when considering the henderences of the 
+      spacesuits and the zero g environment. Furthermore, we have 
+      considerable confidence in the charts and expect that if the 
+      charts and AGS (with radar) solutions differ we would be inclined 
+      to believe the charts and use that solution instead of the AGS 
+      anyway.
+
+5. The following is the most startling conclusion reached today: IF the 
+   LM PNGCS is working but rendezvous radar has failed, we have a 
+   serious problem with the LM since no external data will be input to 
+   the spacecraft systems---PNGCS, AGS or charts. In this case, it our 
+   recommendations that the *command module* execute the TPI and 
+   subsequent midcourse correction maneuvers and the LM do the braking 
+   maneuvers.
+
+   a. The command module would compare its TPI solution with the MSFN. 
+      If the comparison is favorable that maneuver would be executed; if 
+      not, the command module would execute the MSFN delta V's using its 
+      own time of ignition.
+
+   b. The command module would voice relay to the LM the maneuvers it 
+      has executed in order that the LM crew could update the command 
+      module state vectors in the LGC using the Target Delta V program. 
+
+6. I would like to present here the rationale for making the command 
+   module active for TPI and midcourse when only the rendezvous radar 
+   has failed. The justification is based on assuming ourselves the 
+   capability of making a good *midcourse correction* subsequent to TPI  
+   which is extremely important since with not ranging device the 
+   braking maneuver is going to be very difficult for the LM to do. The 
+   whole point is that only the command module is able to maintain a 
+   closed loop knowledge of the situation (with its sextant) and 
+   maintain an up-to-date set of state vectors in the computer to target 
+   the midcourse correction maneuver. Furthermore, it is only able to do 
+   this well if it makes the TPI maneuver, so that its PNGCS senses that 
+   too. It should be noted that this does not use a great deal of CSM 
+   RCS propellant. Nowhere near that budgeted for LM rescue. All of the 
+   other maneuvers are carried out by the LM and the really large RCS 
+   drinker---braking---will also be carried out by the LM. The reason 
+   for that, of course, is that since the LM will be coming in from 
+   below, viewing the command module against a star background, it will 
+   be in a much better position to do the braking maneuver. In addition, 
+   we would prefer to save CSM fuel where possible.
+
+7. An obvious additional advantage to this is that it keeps the 
+   procedure as simple as possible in this critical situation. In fact, 
+   it is a standard CSM TPI for which a great deal of planning and 
+   training will have been carried out. On the other hand, for the LM to 
+   make these maneuvers would require a great deal of coordination and 
+   communication between spacecraft crews in real time which is 
+   undesirable. And, it avoids having to prepare procedures and training 
+   for this special situation.
+
+8. In was stated by FCOD that the command module pilot will be unable to 
+   computer onboard chart solutions for TPI due to the press of other 
+   activity and so they will not be available as a data source.
+
+9. The manner in which the AGS can be used to execute LM chart solutions 
+   is bey loading a zero magnitude maneuver into its External Delta V 
+   processor which zeros the registers and permits it to be used like 
+   the PNGCS Average G program (P-47). The crew would thrust 
+   sequentially along each of the three body axes, probably burning the 
+   largest component first. The sequential operation is necessary since 
+   there is only one digital readout on the DEDA register.
+
+10. I expect that at the next meeting we will review all this and tune 
+    it up a little. We should then probably apply these techniques to 
+    the earlier "pseudo-TPI" maneuver which occurs half way through the 
+    exercise including special considerations associated with a TPI 
+    maneuver that we do not really intend to execute


### PR DESCRIPTION
I've transcribed 68-PA-T-49A: "Fifth "D" Mission Rendezvous Mission Techniques meeting---don't miss Paragraph 5: It's great" to the best of my ability from sources:

  1.  http://www.collectspace.com/resources/tindallgrams/tindallgrams01.pdf 
  2.  http://www.collectspace.com/resources/tindallgrams/1968_tindallgrams.pdf

Page 2 is missing in the first source `tindallgrams01.pdf`, only appearing in `1968_tindallgrams.pdf` and is probably the most likely to contain transcription errors on my part. 

Punctuation is for the most part preserved from the original, except for one instance in which the original has `OK.....` but my transcription contains `OK...` as jekyll in its current configuration changes `...` to an ellipsis, mangling the appearance of `.....`.