### PR TITLE
Add 5 new transcriptions (all 1968).

### DIFF
--- a/66-PA-T-59A.md
+++ b/66-PA-T-59A.md
@@ -1,0 +1,139 @@
+---
+layout: tindallgram
+date: Mar 13, 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 66-PA-T-59A
+subject: Seventh "C" Mission Rendezvous Mission Techniques meeting.
+---
+
+1.  Except for the first item listed below, the entire "C" Mission Rendezvous
+Mission Techqniques meeting of March 8 was devoted to the terminal phase.
+Based on the very great importance FCOD is putting on proper lighting during
+the braking phase, a proposal is being considered for including another little
+tune up maneuver between NSR and TPI.  I mention this here to make sure you
+don't overlook it since it is a rather significant item.
+
+2.  Considerable attention is being given by those responsible to lengthening
+the "C" mission launch window.  Apparently, the constrains for the beginning
+and end of this window are almost solely associated with lighting, and MPAD
+is in the process of compiling all of these constraints on a single plot.
+It will probably be used as a basis of determining nominal lift off time and
+launch window duration as a function of launch date.  One constraint, which
+should be included, is of particular interest to our "C" Mission Rendezvous
+Mission Techniques Panel.  Namely, a perioid of darkness is mandatory between
+the NCC2 and the NSR maneuver in order to provide an opportunity to fine
+align the spacecraft platform in preparation for the sextant rendezvous
+navigation and actual execution of the terminal phase.  Specifically, darkness
+must be available during the period from NCC2 plus 5 minutes until NCC2 plus
+20 minutes.  Of course, if in real time conditions prevent making this platform
+alignment the rendezvous would not neccessarily be abandoned.  The point is this
+constraint should be considered mandatory for launch but not mandatory for
+rendezvous.  This constraint has been relayed to the MPAD mission engineer.
+
+3.  Now, on to the terminal phase.  Our first discussion dealt with the use
+of the TPI crew charts.  It is FCSD's desire to prepare and utilize TPI charts
+on the "C" mission rendezvous in very much the same was as they were used on
+Gemini.  That is, they will develop procedures for the crew to obtain an
+onboard soultion for TPI based on both the charts and closed loop PNGCS results.
+It is this integrated solution which would be compared to the MSFN for
+determining whether the onboard or ground solution should be utilized for TPI.
+The exact procedure for all of this will be the subject of further meetings.
+An important point to be made, however, is that onboard TPI charts do play a
+part in the "C" mission.  This was questioned since apparently on the "D"
+rendezvous, there is some indication no TPI charts will be used in the command
+module since the one-man crew is too busy with Sundisk to work them.
+
+4.  As you know, it is intended that the TPI solutions always be based on a
+particular elevation angle of the target vehicle with respect to the local
+horizontal.  The value to be used now and forever more on the "C" mission
+shall be 27.45°.  The onboard charts have been developed in accordance with
+this and it is FCSD's desire that all future rederence trajectories, mission
+planning, etc., use this same value.  All other organizations have agreed to
+go along with this, however, Ed Lineberry's people (OMAB) are emphasizing
+the fact that using this value of elevation angle will nominally result in a
+situation where the TPI thrust vector will not be along the line of sight to
+the target.  It is expected to deviate by about 6° from that alignment and
+everyone should clearly understand that at this time.  Furthermore, some
+consideration has been given to actually modifying the value of elevation
+angle to be used in real time as noted in last week's minutes.  It has been
+reported that on adjustment in the elevation angle in the order of ½°, to
+be determined at the beginning of the rendezvous exercise, would ensure that
+the thrust vector for TPI would have been along the line of sight. However,
+FCSD maintains this would foul up the charts and that they were more anxious
+to avoid that than to maintain that particular thrust alignment during the
+mission.  Accordingly, no further consideration will be given to changing the
+elevation angle from 27.45°, either in advance of the mission or during it
+with the single, possible exception discussed next.
+
+
+5.  In response to last week's action item, FCSD reported that lighting
+conditions during braking have a higher priority than sticking to the 27.45°
+TPI elevation angle.  The important point to be made here is that trajectory
+dispersions could cause the TPI time, based on the 27.45° elevation angle, to
+slip to such an extent that lighting at braking would be unsatisfactory.
+There are apparently two alternatives which can be considered to avoid ?
+from occuring.  One is a real time adjustment in the TPI elevation angle if
+it becomes apparent that the TPI maneuver has slipped beyond acceptable limits
+and the other is a new proposal by Ed Lineberry that a small adjustment
+maneuver be made between NSR and TPI to return conditions to nominal at both
+TPI and braking.  The rest of this memorandum is devoted to these two
+alternatives.
+
+      (a)  Alternate One.  Immediately after the NSR maneuver the crew takes
+????? ?? sextant observations of the S-IVB to update its state vector, and
+then calls up the TPI targeting program (P-34) to obtain the TPI time. It
+is anticipated that this onboard solution for TPI time based on when the CSM
+will arrive at the position giving the desired elevation angle should be
+quite accurate.  That is, all previous computations were based on ground
+determined state vectors which have a relatively large error in determination
+of TPI time.  The onboard determination using sextant observations should be
+an order of magnitude more accurate.  Accordingly,  at this time in the 
+operation we would have our first accurate indication of TPI time. The crew
+????????????? ???? TPI time with the ground relayed ???????? of ???????
+??????????????????????????? slipped excessively such ???? lighting
+??????????????????????????????? acceptable.  In the event the slip is
+excessive the crew  would terminate and recall P-34 utilizing the "time
+option" to determine the elevation angle consistant with an acceptable
+TPI time.  Since it is neccessary to utilize the "elevation angle option"
+in P-34 to permit a comparison of the onboard and ground solutions, the
+crew would have to terminate and recall P-34 using the elvation angle
+just determined as input.  They would also have to relay the value of
+elevation angle to the ground for their computations.  Obviously, the
+thrusting would not be along the line of sight for would TPI occur at
+27.45°, but proper lighting conditions at braking would be assured.
+
+      (b)  Alternate Two starts out the same way as One.  That is, the
+crew updates the S-IVB state vector using the rendezvous navigation
+system and determines the TPI time and its slippage.  Then, using this
+value of slippage they should be able to make a simple computation to
+determine a maneuver to adjust the TPI back to nominal time while
+retaining the nominal elevation angle.  This maneuver would be horizontal
+and inplane to be made 30 seconds after NSR, probably using the Average G 
+program (P-4?).  The Orbital Mission Analysis Branch (formerly Rendezvous
+Analysis Branch) was given the action item of determining the computational
+technique or chart giving maneuver magnitude vs. desired change in TPI time.
+Since it is expected to be in the order of 1/3 fps for each minute TPI time
+change desired, and since we are talking about TPI time adjustments less
+than 15 minutes, the maneuver should be less than 5 fps.  FCSD was asked
+to work out a detailed timeline which includes this maneuver to see if it
+presents any problems.  One thing we are particularly interested is in
+whether it should be done as a standard procedure regardless of whether
+TPI time slippage was acceptable or not, or if it should only be done if
+some limit has been exceeded.  Assuming the procedure is not too complex,
+my personal preference would be to make it a standard procedure.  Phil
+Shaffer expects to spend some time next week with the "C" crew at the
+Florida AMB and will discuss this with them at that time.
+
+6.  Consideration has been given to having the crew call up the TPI
+targetting program (P-34) immediately after NSR in order to dertmine TPI
+time in order to set the spacecraft clocks.  Currently the concensus is
+that this is not a useful operation and it should be dropped from the
+timeline.
+
+7.  As you can see, we are really getting into the fine detail on the "C"
+rendezvous and I predict that if we spend the next two or three sessions
+going through the mission techniques flow charts, we will be ready to call
+in the rest of the world and we could then ice this whole thing down within
+the next couple of months.  Right now I expect the next meeting will be
+devoted to the review of the flow charts.
+

--- a/68-PA-T-48A.md
+++ b/68-PA-T-48A.md
@@ -1,0 +1,76 @@
+---
+layout: tindallgram
+date: Mar 4, 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 66-PA-T-48A
+subject: Ascent Phase Mission Techniques meeting - February 27, 1968
+---
+1.  In the absence of Charley Parker, our beloved leader, I inherited
+the job of chairing this meeting which probably accounts for why we
+didn't really get an awful lot done. However, there are a couple of
+things that are probably worth reporting.
+
+2.  We discussed the imprtance of the "stage verify" discrete to the
+spacecraft computer.  Apparently, its sole purpose is to initialize the
+DAP such that it may perform properly.  For example, it stops sending
+steering commands to the DPS trim gimbals.  It also changes the spacecraft
+mass used in DAP operations from the ascent stage, plus whatever
+remains of the descent stage, to ascent mass only.  Based on this
+information it computes jet firing duration for attitude control
+differently, of course.  I had been concerned that failure to get this
+signal during Ascent would cause poor attitude control and we are
+initiating a program change request to back up "stage verify" with the
+"lunar surface flag" since whenever that event occurs use of the ascent
+stage only is a certainty.  Jack Craven (FCD) pointed out that due to
+the design of the system the much more probable failure is to get a
+"stage verify" signal prematurely.  If that happened, when we are still
+operating on the DPS, it would stop DPS steering and would make the RCS
+attitude control extemely sluggish.  __That__ would be bad news!  All that
+is required to do this is for either of two relays to inadvertantly
+open.
+
+3.  As you know, we are planning to devote a short period of time
+immediately after landing on the lunar surface to checkout of critical
+systems.  This would be done both onboard and in the MCC leading to a
+GO/NO GO for one CSM revolution (about 2 hours).  This is exactly the
+same sort of thing as the GO/NO GO for one revolution following earth
+launch.  Jack Craven accepted the action item, which I had previously
+discussed with Gene Kranz, to establish how long it should take to do
+this system check in order that we may make all other mission planning
+and screw procedures consistent.  It is expected to be in the order of
+3 minutes, unless it takes a long time to really detect and APS pressure
+leak.  Until the GO/NO GO we intent to remain in a state from which we
+can instantly "abort stage" and go.  After that it will take much
+longer.
+
+4.  Almost all the rest of our discussion dealt with what the command
+module should be doing during and immediately following LM ascent from
+the lunar surface.  One unresolved question was whether or not the
+command module should attempt to observe the LM ascent with the sextant.
+It was not clear what purpose would be served other than more rapid
+aquisition for rendezvous navigation tracking after insertion.  It
+seemed to us the most important thing, of course, was for the command
+module to take whatever steps are neccessary to assure getting a good
+LM state vector in its computer for rendezvous maneuver targetting as
+soon as possible.  It seems almost certain that we should load the
+nomonal LM insertion state vector int the CMC from the ground prior to
+LM ascent to guard against subsequent communication breakdown.  It
+was also agreed that we should probablt prepare the MCC to automatically
+take the LM post-insertion state vector from the LM telemetry and transmit
+it back to the command module.  Whether we would actually do this
+or not depends on whether we lose more by forcing the command module to
+stay in the Uplink Command program (P-27) thereby preventing rendezvous
+tracking and onboard navigation for a substantial period of time.  That
+is, analysis may show yjay with good VHF ranging and/or sextant tracking
+the command module may be able to converge on an acceptable LM state
+vector better without this ground participation, if it gets going more
+quickly.
+
+5.  I guess I am attacking the old "MIT me" in stating that we are
+seriously handicapped by having no reliable definition of the Luminary
+lunar surface and ascent programs (e.g. GSOP Chapters 4 and 5).  I
+understand review copies of these should be available within 3 to 6
+weeks and I am sure nothing more can be done to speed them up.  We'll eat'em
+raw when they get here!
+
+

--- a/68-PA-T-56A.md
+++ b/68-PA-T-56A.md
@@ -1,0 +1,140 @@
+---
+layout: tindallgram
+date: Mar 7, 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 68-PA-T-56A
+subject: Guidance system oriented ground rules for TLI Go/No Go
+---
+
+1.  This memo is to document the guidance system oriented ground rules we
+intend to apply in the development of mission techniques for making the
+Translunar Injection (TLI) Go/No Go decision, unless directed otherwise.
+Effective immediately, it is intended that all RTCC computer programs, MCC
+displays and decision limit lines, crew and ground procedures and timelines,
+mission rules, and related matters will be based on these ground rules.
+They represent a change from the tentative ground rules previously governing
+this work.  Accordingly, it is important that you understand them and make
+your views known right now if you do not concur. This specifically applies
+to the "F" and "G" missions.  In summary:
+
+     (a)  A TLI maneuver will not be attempted if there is __any__ indication
+that the S-IVB IU guidance system is not working properly.
+
+     (b)  A properly operating CSM PNGCS is __not__ mandatory for TLI.  That is,
+it is acceptable to make a TLI maneuver with a failed CSM PNGCS if the
+subsequent alternate mission is considered more valuable than remaining in
+earth orbit.
+
+The remainder of this memo presents the rationale for these ground rules
+and outlines the manner in which the guidance systems' performance may be
+evaluated in flight.
+
+2.  __Degraded S-IVB IU in earth orbit.__
+    Analysis has shown that even with a grossly degraded guidance system,
+the S-IVB is able to perform a TLI maneuver which would permit some sort
+of lunar operations.  Depending on the extent of degradation the lunar
+operation could take the form of a hybrid (non-free return) lunar landing
+mission, an "F" type lunar rendezvous mission, or a lunar flyby.  In all
+cases, the mission would certainly at least start out on a non-free return
+trajectory.  The alternate to this is to not perform the TLI maneuver but
+rather to remain in earth orbit and conduct a rendezvous mission (probably
+"F" type) with the LM and CSM.  The priority of these alternate operations
+is currently in the order listed above: that is, if possible, it is
+preferable to obtain lunar operations experience. We have discussed at
+great length the extent of IU degradation which would still permit
+lunar operations and it is certainly gross.  For example, we are told
+10° misalignment of the IU platform throughout the entire TLI may be
+tolerable.  I note these things since previous ground rules were based
+on considerations of that type, but we have now concluded that they do
+not account for the real problem.  Namely, if the S-IVB has failed to
+any detectable extent we would have very little confidence that it would
+be able to perform any sort of TLI.  That is, probability of its failing
+completely during TLI is very great.  If this were to happen we would not
+only lose the lunar operation, but would lose the capability of doing an
+earth orbital mission as well.  And, on top of that, the grossly perturbated
+TLI would leave us in a serious non-nominal situation. These considerations
+finally led us to the conclusion that we should not attempt to do the TLI
+maneuver if there is any indication that the S-IVB IU is not performing
+properly.
+
+3.  There are two sources of failure indication.  The first is by the S-IVB's
+own failure detection system which indicates failures via telemetry.  The
+second is by comparison with the CSM PNGCS and MSFN tracking.  These
+comparisons, it must be emphasized, are extremely gross.  That is, the S-IVB
+IU is designed to be at least an order of magnitude more precise than the
+CSM PNCCS and the MSFN.  Thus, these monitoring systems---telemetry, CSM,
+and MSFN---do not provide data to prove that the IU is performing normally
+but rather are only able to show us when it has degraded very badly---for
+example, 30 to 1O0 sigma!  Whereas, MSFN's definition of a definitely and
+absolutely broken IU is anything beyond 3 sigma.  Therefore, the actual
+limits we would select for TLI Go/No Go based on the S-IVB IU performance
+evaluation can only be the __smallest__, __dependably__, __detectable__ __failure__.  That
+is, we would use the smallest failure which we can confidently attribute
+to the S-IVB rather than the comparison system itself.  Deviations in
+excess of that amount are certainly true S-IVB IU failures and would result
+in a No Go for TLI, and the alternate mission must be earth orbital.
+
+4.  __CSM PNGCS failure, detected in earth orbit on the first lunar mission
+attempt (F or G)__.
+    If CSM PNGCS failure is detected, the options are:
+
+    (a)  Perform a lunar flyby performing all midcourse corrections on the
+SCS and high speed reentry with the backup systems.
+
+    (b)  Remain in earth orbit and perform long duration spacecraft systems
+tests on the command module and LM.
+
+No LM rendezvous should be considered since command module rescue capability
+is not available with PNGCS failure.  We would certainly not brake into
+lunar orbit either.
+
+It is not clear at this time which of these options is preferable.  In
+fact, this will probably not be known until after completion of the
+mission prior to the one under discussion here.  However, this is not
+important since, as far as we could determine, there is no reason why
+either of these alternate missions could not be performed.  For example,
+it was noted that we can expect the lunar flyby to be on a free return
+trajectory since the S-IVB is assumed to be working normally.  There
+apparently is adequate redundancy in the SCS to be tolerant of further
+systems failures.  Also, consideration may be given to using the PNGCS
+even if it has failed to the extent that the platform is drifting at
+the rate of 5° per hour.  For example, that is just equivalent to the
+SCS.  Indications from all knowledgeable lunar return entry people are
+that no screw safety problems are involved in that mission phase using
+the backup systems, although, of course, the spacecraft may not land
+as close to the recovery ships as we've become accustomed to.  There
+was some question as to whether or not the acceleration time history
+during a backup, constant g entry is tolerable to the crew.  All
+indications to date are that it is acceptable.  To my knowledge, there
+is only one loose end to track down.  And that is, is the SXT/SCT
+mandatory for TLI, or are alternate sighting devices adequate for
+guidance and control system alignment?  We think they are.  If not, the
+SXT will have to be checked before the burn.
+
+5.  By accepting these ground rules, it should be possible to establish
+a monitoring technique which would permit performing TLI on the first
+opportunity even for an Atlantic injection (i.e., about 100 minutes 
+after lift off).  The technique would be to compare the CSM PNGCS and
+the S-IVB during the launch phase and earth parking orbit.  If this
+comparison is favorable, that is, to within the tolerance to be
+specified as described in paragraph 3, it can be assumed that both the
+S-IVB IU and the CSM PNGCS are performing well and we would execute TLI.
+If the compnrison were not within those limits, one of the systems must
+have failed by our definition, but we have insufficient knowledge to
+determine which one without performing a CSM PNGCS platform alignment in
+earth orbit.  This would be carried out as soon after the failure was
+detected as possible, but would certainly necessitate going another
+revolution and TLI could not occur until the second opportunity.  If the
+failure turns out to be in the IU, we would not perform TLI but would
+carry out a CSM/LM long duration mission with rendezvous in earth orbit.
+If the failure is in the CSM PNGCS, we have the option (to be determined
+preflight) of doing TLI at the second opportunity and performing a lunar
+flyby, or of scrubbing TLI for that flight and remaining in earth orbit.
+
+
+6.  I would like to conclude by expressing my appreciation to Carl Huss
+and his Alternate Mission Review Panel for helping us at his February 29
+"F" and "G" Lunar Mission meeting.  Our last TLI Mission Techniques
+meeting got stalled on top dead center in the absence of a clear understanding
+of alternate mission priority, among other things, and they
+gave us the needed push to get going again.

--- a/68-PA-T-57A.md
+++ b/68-PA-T-57A.md
@@ -1,0 +1,136 @@
+---
+layout: tindallgram
+date: Mar 12, 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 68-PA-T-57A
+subject: Sixth Midcourse Phase Mission Techniques meetings
+---
+
+1.  The Midcourse Phase Data Priority meeting of March 6 was devoted to
+the earth orbital phase evaluation of guidance systems to make the translunar
+injection (TLI) Go/No Go decision.  It was reported at the outset
+that a new set of ground rules have been established with regard to this
+subject.  They are:
+
+    (a)  A TLI maneuver will not be attempted if there is any indication
+that the S-IVB IU guidance system is not working properly.
+
+    (b)  A properly operating CSM PNGCS is not mandatory for TLI.  That
+is, it is acceptable to make a TLI maneuver with a failed CSM PNGCS if
+the subsequent alternate mission is considered more valuable than remaining
+in earth orbit.
+
+Rationale for these ground rules is given in Memorandum No. 68-PA-T-56A
+(H. W. Tindall), dated March 7, 1968.  The manner in which we may detect
+S-IVB IU failure is also presented in that memo and is partially reproduced
+in this one to make the rest of it more understandable.
+
+2.  There are two sources of S-IVB IU failure indication.  The first is by
+the S-IVB's own failure detection system which indicates failures via
+telemtry.  The second is by comparison with the CSM PNGCS and MSFN tracking.
+These comparisons, it must be emphasized, are extremely gross.  That
+is, the S-iVB IU is designed to be at least an order of magnitude more
+precise than the CSM PNGCS and the MSFN.  Thus, these monitoring systems---
+telemetry, CSM and MSFN---do not prodive data to prove that the IU is
+performing normally but rather are only able to show us when it has
+degraded very badly---for example, 30 to 100 sigma! Whereas, MBFC's
+definition of a definitely and absolutely broken IU is anything beyond
+3 sigma.  Therefore, the actual limits we would select for TLI Go/No Go
+based on the S-IVB IU performance evaluation can only be the smallest,
+dependably, detectable failure.  That is, we would use the smallest
+failure which we can confidently attribute to the S-IVB rather than the
+comparison system itself.  Deviations in excess of that amount are
+certainly true S-IVB IU failures and would result in a No Go for TLI.
+
+3.  At this meeting we added another ground rule regarding guidance systems
+checks prior to TLI.  The question was whether or not the sextant and scanning
+telescope are mandatory for TLI Go/No Go.  If they were it would be neccessary
+for the crew to check them out.  However, analysis performed by MPAD has shown
+that LM PNGCS alignment with the AOT and undocked COAS alignment of the PNGCS
+and SCS can be accomplished with sufficient accuracy to ensure safe return to
+earth after TLI.  Accordingly, as of this time we are proceding under the
+assumption that checkout of the sextant and telecope need not be performed
+prior to TLI.  If you do not agree with this decision, you should say so
+immediately.
+                        
+4.  By accepting these ground rules, neither a platform alignment nor sextant
+check need be ???????? in the ?????????.  Therefore, it should be possible
+to establish a monitoring technique which would permit performing TLI on
+the first opportunity even for an Atlantic injection (i.e., about 100 minutes
+after lift off).  The technique would be to compare the CSM PNGCS and the
+S-IVB IU during the launch phase and perhaps in earth parking orbit.  If
+this comparison is favorable, it can be assumed that both the S-IVB IU and
+the CSM PNGCS are performing well and we would execute TLI.  If the comparison
+were not within those limits, one of the systems must have failed by our
+definition, but we may have insufficient knowledge to determine which one
+without performing a CSM PNGCS platform alignment in earth orbit.  This would
+probably require going another revolution and, thus, TLI could not occur until
+the second opportunity.  If the failure turns out to be in the IU, we would
+not perform TLI.
+			  
+5.  The Guidance and Performance Branch outlined their proposal for processing
+and displaying launch phase telemetry in the control center to evaluate S-IVB
+and spacecraft guidance systems performance as the prime TLI Go/No Go data
+source.  They recommend plotting differences in the three components of
+velocity as determined from the PNCGS and S-IVB IU state vectors.  These
+would be plotted in real time on strip chart recorders in the Mission Control
+Center.  It is felt they would be extremely effective in not only detecting
+system failures but also for isolating exactly what type of failure has
+occurred.  Limits would be established on three differences based on accuracy
+of the CSM PNCGS in accordance with the philosophy noted in paragraph 2.
+There is one big source of "error" in these plots resulting from our inability
+to align the CSM PNGCS accurately in azimuth on the launch pad.  We had a
+similar problem, you recall, on Gemini and our solution here is about the
+same.  It is proposed that a simple computation be performed similar ro the
+platform alignment update carried out in the Gemini program at 100 seconds
+after lift off.  This computation was based on the assumption that any
+difference in the horizontal velocity vectors detected when comparing the
+spacecraft to the S-IVB is due to gyro compassing misalignment of the spacecraft
+IMU on the launch pad.  It is a simple way of determining what this
+misalignment is in order to improve the comparison by mathematically accounting
+for it in the plots during the remainder of the launch phase.  In addition, it
+makes the magnitude of the misalignment available for use in later guidance
+systems pergormance evaluation tests inflight.
+
+6.  Flight Control Division and MPAD are jointly engaged in perparing RTCC
+program requirements based on this technique including display format and
+equation formulation.  These program requirements should be in a form
+suitable for transmittal to FCD within 2 weeks, and negotiating will then
+begin to determine whether or not they can be included in the earlier
+manned Saturn 5 launches.  They would be desirable on the "D" mission,
+possible mandatory for the "E", and certainly mandatory for the "F" and "G".
+
+7.  We next discussed the question of whether or not the launch phase systems
+evaluation for first opportunity TLI Go/No Go described above is sufficient
+all by itself.  That is, platform drift checks based on telemetry gimbal
+angles from the SIV-B IU and the spacecraft PNGCS have been proposed as a
+supplement to the launch phase comparison, but there are obvious problems
+associated with that procedure which may make it rather useless---although
+I'm sure they will be monitored grossly.  For example, the data is not
+time synchronized nor even homogeneous.  As a result, it would be necessary
+for the spacecraft to maintain minute attitude rates over the measurement
+period which is almost impossible to achieve.  Furthermore, structural
+bending and thermal warping also create very large errors---comparable to
+the differences we're looking for.  MPAD was given the action item of
+determining if such a test contributes significantly to our confidence
+for TLI since if it doesn't we can simplify things a greal deal by
+eliminating the whole procedure.
+
+8. Finally, we investigate how we would determine which system had failed
+if the launch evaluation shown disagreement.  It appears necessary to perform
+a platform alignment, or at least a determination of its orientation.  This
+would probably force delay of TLI until the second opportunity.  We are
+currently investigating the following approach:
+
+    (a)  Evaluate the CBM platform torquing angles.  The x and y axis should
+be near zero and the z axis should equal the pad misalignment as detected
+in the launch phase.  If not within limits it has failed.
+
+    (b)  Using MSFN tracking for orbit determination, compare the actual
+trajectory against the S-IVB IU insertion state vector trajectory.  This
+requires 1½ revolutions on tracking.  Disagreement beyond limits indicates
+S-IVB IU failure.
+
+9.  Obviously, we have a lot to do.  But if the ground rules are accepted
+it is mostly a matter of implementing a technique we understang.  Believe
+it or not, I think we've got this TLI thing pretty nearly licked.  I hope so!

--- a/68-PA-T-61A.md
+++ b/68-PA-T-61A.md
@@ -1,0 +1,56 @@
+---
+layout: tindallgram
+date: Mar 4, 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 66-PA-T-61A
+subject: Seventh "D" Mission Rendezvous Mission Techniques meeting.
+---
+
+1. The "D" Rendezvous Mission Techniques meeting of March 10 was probably
+one of the least productive so far, and I sincerely apologize for it.  I
+must have been tired or something.  Even so, with all that talent present,
+there must be something worthwhile reporting.
+
+
+2. At one of our earlier meetings we tentatively established that platform
+alignments would be performed by both vehicles during each period of darkness
+throughout the rendezvous exercise.  Paul Pixley (MPAD) presented some data
+at this meeting which showed that, from a rendezvous navigation standpoint,
+loss of observational data---rendezvous radar in the LM and sextant in the
+CSM---during platform alignment hurts us more than a little platform drift.
+Accordingly, it is their proposal that platform alignments onle be performed
+prior to the separation burn which initiates the football rendezvous in the
+beginning and in the darkness period shared by the psuedo-TPI when the LM
+is above the command module.  This applies to both the LM and CSM. Unless
+someone has reason for disagreeing with this, their recommendation is accepted
+and all further work should be based upon it.
+
+
+3.  In response to an action item from the very first meeting, the 0rbital
+Mission Analysis Branch (formerly the Rendezvous Analysis Branch) reported
+their progress on developing techniques for insuring proper station coverage
+and lighting conditions during the rendezvous exercise in spite of trajectory
+perturbations earlier in the mission.  The most significant of these
+perturbations, of course, is failure to launch on time.  As a result of
+their work, it is anticipated they will recommend selection of an earlier
+nominal launch time and change in direction of the SPS engine tests early
+in the mission so that the spacecraft will nominally fly in a higher orbit,
+during the period between them.  In addition, it will probably be recommended
+that these big SPS burns be separated in time by approximately a day instead
+of occurring within the same period of activity.  If these things are done
+it will be possible to compensate for lift off time delays by decreasing the
+horizontal, in-plane component of these SPS burns in real time such that the
+spacecraft does not go to such a high altitude, thereby shortening the
+orbital period during that period.  The implementation to carry out targetting
+of these maneuvers in real time may utilize the rendezvous mission planning
+tools in the RTCC that are already available.  Their proposed approach would
+be to modify the SPS burns using the Gemini Agena maneuver logic to cause
+the spacecraft to rendezvous with a phantom target.  The phantom target
+being where the spacecraft would have been if it had been launched on
+time and followed the nominal maneuver sequence. If this technique
+proves to be as resonable as it seems to be now, changes to the nominal
+mission plan noted above will be processed through the FOP by Morrin
+Jenkins.
+
+4. I just reread that last paragraph and it sounds like I'm still asleep.
+Does it make sense to you?


### PR DESCRIPTION
Replaced illegible text with '?' but tried to keep word lengths accurate. The monospace font of the typewriter makes this easier - just do a vertical comparison to make sure characters are aligned.

Tindall keeps writing 'PNGCS' instead of 'PGNCS' (New word: Tindallism!). I have used his spelling so perhaps a new definition in the glossary is warranted?

Used double-underscore to represent __underlining__.

I deserve a beer for 68-PA-T-57A. Source four quality sucks.

Will continue work on 1968 as this is the area which interests me most.