### PR TITLE
Add 67-FM1-38

### DIFF
--- a/67-FM1-38.md
+++ b/67-FM1-38.md
@@ -1,0 +1,16 @@
+---
+layout: tindallgram
+date: May 17 1997
+from: FM/Deputy Chief
+serial: 67-FM1-38
+subject: Reduced L/D presents a spacecraft computer program problem
+---
+This note is to help insure that the word gets around regarding reduced
+command module reentry L/D. MIT has heard rumors that the L/D may be
+reduced to a value of .25 and emphasized during our program development
+plan meeting that they are fairly certain the present spacecraft computer
+program formulation will not handle that. The current formulation
+is designed to handle a minimum L/D value of .30 and, although they do
+not know how far this limit can be extended, they feel certain major
+rework will be required for .25. This is no a new discovery. Our
+reentry experts in MPAD have been saying the same thing for some time.


### PR DESCRIPTION
Add 67-FM1-38 from pg. 19 of http://web.mit.edu/digitalapollo/Documents/Chapter7/tindallgrams.pdf

I'm not sure of the policy on this but in the pdf there's the line `computer program formulation will not handle that, The current formulation`. The character between `that` and `The` looks like a comma, but should probably be a period. I set it to a period in my change but I can swap it if needed.

Also should I add Jekyll font matter for the `To: See list` line?
