### PR TITLE
Add 69-PA-T-84A

### DIFF
--- a/69-PA-T-84A.md
+++ b/69-PA-T-84A.md
@@ -1,0 +1,22 @@
+---
+layout: tindallgram
+date: June 4 1969
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 69-PA-T-84A
+subject: G Rendezvous Navigation OJT is proposed
+---
+CMP Mike COllins called the other day to ask if there is any reason
+why he should not do active rendezvous navigation between DIO and PDI
+on the G mission. That is, he would like to run PDO incorporating
+sextant and VHF ranging data to update the LM state vector in the
+CMC. His primary purpose is to get some on-the-job training (OJT)
+before he has to do it for real during the upcoming rendezvous. You
+recall, this was in the F Flight Plan and I assume John Young did
+it, although I'm not sure. I told him that I knew of no reason why
+he shouldn't and I have asked several other experts who agree. I
+also suggested to Mike that he contact John personally to get any
+pertinent F mission feedback.
+
+This memo is to inform you that this activity will be included in
+the G mission timeline unless somebody comes up with a valid
+objection. Do you have one?


### PR DESCRIPTION
From http://www.collectspace.com/resources/tindallgrams/1969_tindallgrams.pdf page 6.
Edits:
- Removed comma from date, "June 4, 1969" to "June 4 1969"
- I think the acronym between "run" and "incorporating" on line 3 is "PDO". I looked it up and PDO means "Process Data Object", defined as `provides access to application objects within a device. A PDO transfers short blocks of high priority data in real time.`