### PR TITLE
Add transcription of 68-PA-T-222A

### DIFF
--- a/68-PA-T-222A.md
+++ b/68-PA-T-222A.md
@@ -1,0 +1,26 @@
+---
+layout: tindallgram
+date: Oct 16 1968
+from: PA/Chief, Apollo Data Priority Coordination
+serial: 68-PA-T-222A
+subject: C' maneuvers - SPS versus RCS crossover
+tags:
+    - MPAD
+    - RCS
+    - SPS
+---
+
+
+Neil Townsend (EP2) informed me by phone - and will supply written
+confirmation - that the minimum duration SPS burn for C' should be
+no less than 0.5 seconds.  We had been assuming something smaller.
+According to MPAD (Otis Graf, FM7) this makes the crossover point
+between use of the RCS versus the SPS engine:
+
+Translunar midcourse correction - 5 fps
+
+Transearth midcourse correction - 12 fps
+
+These values will be explained completely in an FM7 memo soon to be
+distributed.  I just want everybody to be aware of the new values and
+to start using them in his planning.


### PR DESCRIPTION
From http://www.collectspace.com/resources/tindallgrams/tindallgrams01.pdf, page 10.

I had to add an extra line break between the "Translunar..." and the "Transearth..." lines.  Otherwise, Markdown joins them.

Also, similar to [my other PR](https://github.com/seanredmond/Tindallgrams/pull/41), I couldn't find a way to match the source indentation without activating code formatting.